### PR TITLE
Init templates

### DIFF
--- a/src/hip_cargo/_container_image.py
+++ b/src/hip_cargo/_container_image.py
@@ -1,1 +1,1 @@
-CONTAINER_IMAGE = "ghcr.io/landmanbester/hip-cargo:latest"
+CONTAINER_IMAGE = "ghcr.io/landmanbester/hip-cargo:init-templates"

--- a/src/hip_cargo/cabs/generate_cabs.yml
+++ b/src/hip_cargo/cabs/generate_cabs.yml
@@ -5,7 +5,7 @@ cabs:
     name: generate_cabs
     info:
       Generate Stimela cab definition from Python CLI function.
-    image: ghcr.io/landmanbester/hip-cargo:latest
+    image: ghcr.io/landmanbester/hip-cargo:init-templates
     inputs:
       module:
         info:

--- a/src/hip_cargo/cabs/generate_function.yml
+++ b/src/hip_cargo/cabs/generate_function.yml
@@ -5,7 +5,7 @@ cabs:
     name: generate_function
     info:
       Generate Python function from Stimela cab definition.
-    image: ghcr.io/landmanbester/hip-cargo:latest
+    image: ghcr.io/landmanbester/hip-cargo:init-templates
     inputs:
       cab-file:
         info:

--- a/src/hip_cargo/cabs/generate_schemas.yml
+++ b/src/hip_cargo/cabs/generate_schemas.yml
@@ -5,7 +5,7 @@ cabs:
     name: generate_schemas
     info:
       Generate Pydantic schemas of tunable parameters from Python CLI modules.
-    image: ghcr.io/landmanbester/hip-cargo:latest
+    image: ghcr.io/landmanbester/hip-cargo:init-templates
     inputs:
       module:
         info:

--- a/src/hip_cargo/cabs/init.yml
+++ b/src/hip_cargo/cabs/init.yml
@@ -5,7 +5,7 @@ cabs:
     name: init
     info:
       Initialize a new hip-cargo project with scaffolding and Stimela cab support.
-    image: ghcr.io/landmanbester/hip-cargo:latest
+    image: ghcr.io/landmanbester/hip-cargo:init-templates
     inputs:
       project-name:
         info:

--- a/src/hip_cargo/core/init.py
+++ b/src/hip_cargo/core/init.py
@@ -89,6 +89,7 @@ def init(
         d.mkdir(parents=True, exist_ok=True)
 
     # Write template files
+    _write_template("CLAUDE.md", project_dir / "CLAUDE.md", subs)
     _write_template("pyproject.toml", project_dir / "pyproject.toml", subs)
     _write_tbump(project_dir / "tbump.toml", subs, auto_changelog=auto_changelog)
     if auto_changelog:
@@ -157,6 +158,7 @@ def init(
         f'CONTAINER_IMAGE = "ghcr.io/{github_user}/{project_name}:latest"\n',
     )
     _write_file(project_dir / "tests" / "__init__.py", "")
+    _write_template("test_roundtrip.py", project_dir / "tests" / "test_roundtrip.py", subs)
     _write_file(
         project_dir / "tests" / "test_install.py",
         f"def test_import():\n"

--- a/src/hip_cargo/templates/CLAUDE.md
+++ b/src/hip_cargo/templates/CLAUDE.md
@@ -1,0 +1,263 @@
+# CLAUDE.md — Project Context
+
+This project was bootstrapped with [`hip-cargo init`](https://github.com/landmanbester/hip-cargo).
+It is a **hip-cargo package**: a Python CLI whose commands are decorated so that
+Stimela cab definitions are generated automatically from the CLI source. Cabs
+let the same commands be invoked from Stimela recipes and from `<CLI_COMMAND>`
+on the command line interchangeably.
+
+When working in this repo, treat the patterns below as load-bearing — they are
+what makes the round-trip between CLI source, generated cabs, and container
+fallback work. If you find yourself wanting to deviate, stop and check
+[hip-cargo's own docs](https://github.com/landmanbester/hip-cargo) first.
+
+---
+
+## 1. Package Layout
+
+```
+<PROJECT_NAME>/
+├── src/<PACKAGE_NAME>/
+│   ├── __init__.py
+│   ├── _container_image.py    # CONTAINER_IMAGE — single source of truth for the image tag
+│   ├── cli/                   # Lightweight Typer wrappers. THIS is what generate-cabs parses.
+│   │   ├── __init__.py        # Builds the Typer `app` and registers subcommands
+│   │   └── onboard.py         # One file per subcommand (delete onboard once setup is done)
+│   ├── core/                  # Real implementations. Heavy deps live here.
+│   │   ├── __init__.py
+│   │   └── onboard.py         # Mirrors cli/onboard.py — same function name, no decorators
+│   └── cabs/                  # AUTO-GENERATED Stimela YAMLs. Do NOT hand-edit.
+│       ├── __init__.py
+│       └── onboard.yml
+├── tests/
+│   ├── test_install.py
+│   └── test_roundtrip.py      # Guards the CLI → cab → CLI round-trip
+├── Dockerfile                 # Builds the image referenced by _container_image.py
+├── pyproject.toml
+├── tbump.toml                 # Release tooling — updates _container_image.py + cabs
+├── .pre-commit-config.yaml    # Runs generate-cabs on every commit
+└── .github/workflows/
+    ├── ci.yml
+    ├── publish.yml             # PyPI on tag push
+    ├── publish-container.yml   # ghcr.io on tag + every push to <DEFAULT_BRANCH>
+    └── update-cabs.yml         # Regenerates cabs on merge to <DEFAULT_BRANCH>
+```
+
+### Role of each directory
+
+| Directory | What lives there | What does NOT live there |
+|---|---|---|
+| `cli/` | Thin Typer wrappers with `@stimela_cab` (and optional `@stimela_output`). One file per command. **Imports from `core/` must be lazy** (inside the function body). | Heavy imports at module top. Business logic. NumPy / pandas / domain libs. |
+| `core/` | The actual implementation. Type-hinted function with the same name as the CLI wrapper, but **no Typer / hip-cargo decorators**. Free to import anything. | Typer. `@stimela_cab`. UI concerns. `typer.Exit(...)`. |
+| `cabs/` | Generated `<command>.yml` files. Committed to source control. Loaded by Stimela. | Anything you wrote by hand. Drift from `cli/*.py`. |
+
+### Adding a new command
+
+1. Create `src/<PACKAGE_NAME>/cli/<name>.py` with a `@stimela_cab`-decorated
+   Typer function. Lazily import the core implementation inside the function.
+2. Create `src/<PACKAGE_NAME>/core/<name>.py` with the real implementation —
+   same function name, no decorators, free to import heavy deps.
+3. Register the new command in `src/<PACKAGE_NAME>/cli/__init__.py` (next to
+   the existing `onboard` registration; mirror its pattern).
+4. Commit. The pre-commit hook regenerates `src/<PACKAGE_NAME>/cabs/<name>.yml`
+   automatically.
+
+**Never** create files under `cabs/` by hand. They are derived artefacts.
+
+---
+
+## 2. Lightweight vs Full Installation
+
+This package supports two install modes. The split is what makes the
+container-fallback pattern below work.
+
+| Mode | Command | What it pulls | When to use |
+|---|---|---|---|
+| **Lightweight** | `pip install <PROJECT_NAME>` | `hip-cargo` + `typer` only | Cab consumers (Stimela), CI machines that only need to dispatch commands into containers, anyone who already has the project's container image available. |
+| **Full** | `pip install <PROJECT_NAME>[full]` | Lightweight + everything listed under `[project.optional-dependencies].full` in `pyproject.toml` | Local development; native (non-container) execution. |
+
+The lightweight install is **always sufficient to invoke any command** because
+the generated CLI wrappers fall back to running the same command inside the
+project's container when native imports fail (see §3).
+
+### When you add a heavy dep
+
+- Add it to `[project.optional-dependencies].full` in `pyproject.toml`, **not**
+  to the top-level `dependencies`. The top-level list must stay tiny so the
+  lightweight install remains lightweight.
+- Import it **only from inside `core/`**. Never import it from `cli/` at module
+  scope.
+
+---
+
+## 3. Container Fallback & Backends
+
+Every generated CLI wrapper in `cli/*.py` follows the same shape (this is
+emitted by `hip-cargo generate-function`, but the pattern matters when you
+write a new command by hand too):
+
+```python
+def my_command(...):
+    if backend == "native" or backend == "auto":
+        try:
+            from hip_cargo.utils.runner import preflight_remote_must_exist
+            preflight_remote_must_exist(my_command, dict(...))
+            from <PACKAGE_NAME>.core.my_command import my_command as my_command_core
+            my_command_core(...)
+            return
+        except ImportError:
+            if backend == "native":
+                raise
+    # Heavy deps missing OR backend explicitly chose a container → run in container.
+    from hip_cargo.utils.config import get_container_image
+    from hip_cargo.utils.runner import run_in_container
+    image = get_container_image("<PROJECT_NAME>")
+    run_in_container(my_command, dict(...), image=image, backend=backend, ...)
+```
+
+### How `--backend` flows
+
+Every command auto-grows two parameters via `hip-cargo generate-function`:
+
+| Flag | Values | Effect |
+|---|---|---|
+| `--backend` | `auto` (default), `native`, `apptainer`, `singularity`, `docker`, `podman` | `auto` tries native then falls back to a detected container runtime. `native` forces in-process execution and surfaces the `ImportError` if `[full]` is not installed. The explicit backends skip the native attempt entirely and dispatch into the matching runtime. |
+| `--always-pull-images` | bool | Forces a fresh `pull` before each container run. |
+
+Both flags are decorated with `StimelaMeta(skip=True)` so they appear in the
+Python CLI but **not** in the generated cab YAML — Stimela manages container
+execution on its own side and doesn't need them.
+
+### Image resolution
+
+The image tag is owned by `src/<PACKAGE_NAME>/_container_image.py`:
+
+```python
+CONTAINER_IMAGE = "ghcr.io/<GITHUB_USER>/<PROJECT_NAME>:latest"
+```
+
+Three things keep this in sync — do not bypass them:
+
+1. **Feature branches:** Edit `_container_image.py` by hand to point at your
+   branch tag (e.g. `:my-feature`). The `publish-container.yml` workflow builds
+   and pushes that tag on every push of the PR.
+2. **Merge to `<DEFAULT_BRANCH>`:** The `update-cabs.yml` workflow resets the
+   tag to `latest` and regenerates cabs in a `[skip checks]` commit.
+3. **Releases:** `tbump <version>` rewrites the tag to the semantic version and
+   regenerates cabs as a `before_commit` hook.
+
+### Remote URIs (S3 / GCS / Azure)
+
+Path-typed parameters (`File`, `Directory`, `MS`, `URI`) accept both local
+paths and remote URIs (`s3://...`, `gs://...`, `az://...`). When the path is
+remote:
+
+- `_resolve_mounts` skips it (nothing to bind-mount).
+- `preflight_remote_must_exist` checks existence via fsspec.
+- `run_in_container` forwards the matching credentials (`AWS_*`, `~/.aws`,
+  `GOOGLE_APPLICATION_CREDENTIALS`, `~/.config/gcloud`, `AZURE_*`, `~/.azure`).
+
+Users who want native remote access install the right extra: `pip install
+hip-cargo[s3]`, `[gcs]`, or `[azure]`. Without it, the wrapper's existing
+`try/except ImportError` routes them into the container, which already has the
+backends.
+
+---
+
+## 4. Cab Generation is Automatic
+
+**The `src/<PACKAGE_NAME>/cabs/*.yml` files are generated artefacts. Never edit
+them by hand and never run `hip-cargo generate-cabs` manually.**
+
+Three automated paths keep them in sync with `cli/*.py`:
+
+1. **Pre-commit hook** (`.pre-commit-config.yaml`): on every commit, runs
+   `hip-cargo generate-cabs --module src/<PACKAGE_NAME>/cli/*.py --output-dir
+   src/<PACKAGE_NAME>/cabs`. If it modifies files, pre-commit will "fail" the
+   commit — re-run `git add -u && git commit` to include the updates.
+2. **`update-cabs.yml` workflow**: on merge to `<DEFAULT_BRANCH>`, resets the
+   container tag to `latest` and regenerates cabs in a `[skip checks]` commit.
+3. **`tbump`**: on release, rewrites the container tag to the version and
+   regenerates cabs.
+
+If you ever see a cab YAML in a diff that wasn't generated by one of these
+three paths, that's a bug — revert it and edit the corresponding `cli/*.py`
+instead.
+
+### How CLI source maps to cab YAML
+
+- `@stimela_cab(name=..., info=...)` → the cab's name and top-level info.
+- `@stimela_output(...)` → entries under `outputs:` in the cab.
+- Each Typer parameter → an entry under `inputs:` (dtype inferred from the type
+  hint, `info` from `help=`, defaults from `= ...`).
+- `Annotated[..., StimelaMeta(skip=True)]` → omitted from the cab (used for
+  `--backend`, `--always-pull-images`, etc.).
+- `Annotated[..., StimelaMeta(metadata={"rich_help_panel": "Inputs", "tunable":
+  True})]` → flows into the cab's `metadata:` dict.
+- Inline comments after `Annotated[...]` rows are preserved through the round
+  trip — they show up as `# noqa: ...` or similar on the matching cab field.
+
+---
+
+## 5. Round-Trip Tests
+
+The round-trip test in `tests/test_roundtrip.py` is **not optional** — it is
+how this project guarantees that `cli/*.py` and `cabs/*.yml` agree.
+
+It runs:
+
+```
+cli/<cmd>.py  ──(generate-cabs)──►  cabs/<cmd>.yml  ──(generate-function)──►  <cmd>.py
+```
+
+…then asserts the regenerated `<cmd>.py` is byte-identical (after `ruff
+format`) to the original `cli/<cmd>.py`. If you write a CLI wrapper in a shape
+that hip-cargo cannot round-trip, the test fails and the cab is unreliable.
+Fix the source, not the test.
+
+Add a new round-trip case to `tests/test_roundtrip.py` whenever you add a new
+command under `cli/`.
+
+---
+
+## 6. Mandatory Dev Workflow
+
+After every code change run:
+
+```bash
+uv run ruff format . && uv run ruff check . --fix
+```
+
+This is non-negotiable — the pre-commit hook and CI both enforce it, and
+generated code is formatted with the same configuration, so divergence breaks
+the round-trip.
+
+### Other rules
+
+- **Python 3.10+.** Use modern syntax (`X | Y`, `list[int]`, etc.).
+- **Type hints on every function signature.**
+- **Lazy imports in `cli/`.** Heavy imports live in `core/` only, and `cli/`
+  imports from `core/` inside the function body.
+- **Typer Option syntax:**
+  - Required: `Annotated[T, typer.Option(..., help="...")]` (no `= default`).
+  - Optional w/ default: `Annotated[T, typer.Option(help="...")] = default`.
+  - Optional None: `Annotated[T | None, typer.Option(help="...")] = None`.
+  - **Never pass `None` as the positional default to `typer.Option()`** — it
+    raises `AttributeError`.
+- **Comma-separated lists:** use `ListInt`, `ListFloat`, `ListStr` from
+  `hip_cargo`, with their matching `parse_list_*` parsers.
+- **UPath-backed path types:** `File`, `Directory`, `MS`, `URI` are
+  `NewType(..., UPath)`. Generated CLIs use `parser=parse_upath` so the same
+  signature accepts local paths and remote URIs.
+- **Commits:** use Conventional Commits (`feat:`, `fix:`, `chore:`, …). The
+  `update-cabs` bot uses `[skip checks]` to bypass required status checks; do
+  not add that tag to human commits.
+
+---
+
+## 7. Where to Go Deeper
+
+- hip-cargo source & docs: <https://github.com/landmanbester/hip-cargo>
+- Stimela: <https://github.com/caracal-pipeline/stimela>
+- Twelve-factor principles guide most architectural decisions in this repo:
+  <https://12factor.net/>

--- a/src/hip_cargo/templates/onboard_cli.py
+++ b/src/hip_cargo/templates/onboard_cli.py
@@ -1,15 +1,60 @@
-from hip_cargo import stimela_cab
+from typing import Annotated, Literal
+
+import typer
+from hip_cargo import StimelaMeta, stimela_cab
 
 
 @stimela_cab(
     name="onboard",
     info="Print setup instructions for CI/CD, PyPI publishing, and GitHub configuration.",
 )
-def onboard():
+def onboard(
+    backend: Annotated[
+        Literal["auto", "native", "apptainer", "singularity", "docker", "podman"],
+        typer.Option(
+            help="Execution backend.",
+        ),
+        StimelaMeta(
+            skip=True,
+        ),
+    ] = "auto",
+    always_pull_images: Annotated[
+        bool,
+        typer.Option(
+            help="Always pull container images, even if cached locally.",
+        ),
+        StimelaMeta(
+            skip=True,
+        ),
+    ] = False,
+):
     """
     Print setup instructions for CI/CD, PyPI publishing, and GitHub configuration.
     """
-    # Lazy import the core implementation
-    from <PACKAGE_NAME>.core.onboard import onboard as onboard_core  # noqa: E402
+    if backend == "native" or backend == "auto":
+        try:
+            # Lazy import the core implementation
+            from <PACKAGE_NAME>.core.onboard import onboard as onboard_core  # noqa: E402
 
-    onboard_core()
+            # Call the core function with all parameters
+            onboard_core()
+            return
+        except ImportError:
+            if backend == "native":
+                raise
+
+    # Resolve container image from installed package metadata
+    from hip_cargo.utils.config import get_container_image  # noqa: E402
+    from hip_cargo.utils.runner import run_in_container  # noqa: E402
+
+    image = get_container_image("<PROJECT_NAME>")
+    if image is None:
+        raise RuntimeError("No Container URL in <PROJECT_NAME> metadata.")
+
+    run_in_container(
+        onboard,
+        dict(),
+        image=image,
+        backend=backend,
+        always_pull_images=always_pull_images,
+    )

--- a/src/hip_cargo/templates/pyproject.toml
+++ b/src/hip_cargo/templates/pyproject.toml
@@ -16,8 +16,19 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "hip-cargo>=0.1.3",
+    "hip-cargo>=0.2.0",
 ]
+
+# Lightweight install (default):  pip install <PROJECT_NAME>
+#     Only pulls hip-cargo + typer. Suitable for cab consumers (e.g. stimela)
+#     and for running commands via container fallback. Generated CLI wrappers
+#     lazy-import core/, so when heavy deps are missing the wrapper drops into
+#     run_in_container() automatically.
+# Full install:                    pip install <PROJECT_NAME>[full]
+#     Adds the heavy runtime deps that core/ implementations need to execute
+#     natively. Add new deps to the "full" extra below as you grow core/.
+[project.optional-dependencies]
+full = []
 
 [project.urls]
 Homepage = "<GITHUB_URL>"

--- a/src/hip_cargo/templates/tbump.toml
+++ b/src/hip_cargo/templates/tbump.toml
@@ -50,7 +50,7 @@ cmd = "python -c \"import re; p = 'src/<PACKAGE_NAME>/_container_image.py'; t = 
 
 [[before_commit]]
 name = "Regenerate cab definitions with release version"
-cmd = "<CLI_COMMAND> generate-cabs --module 'src/<PACKAGE_NAME>/cli/*.py' --output-dir src/<PACKAGE_NAME>/cabs"
+cmd = "hip-cargo generate-cabs --module 'src/<PACKAGE_NAME>/cli/*.py' --output-dir src/<PACKAGE_NAME>/cabs"
 
 [[before_commit]]
 name = "Stage updated cab definitions"
@@ -78,7 +78,3 @@ search = 'version = "{current_version}"'
 [[file]]
 src = "src/<PACKAGE_NAME>/__init__.py"
 search = '__version__ = "{current_version}"'
-
-[[file]]
-src = "src/<PACKAGE_NAME>/_container_image.py"
-search = 'CONTAINER_IMAGE = "ghcr.io/<GITHUB_USER>/<PROJECT_NAME>:{current_version}"'

--- a/src/hip_cargo/templates/test_roundtrip.py
+++ b/src/hip_cargo/templates/test_roundtrip.py
@@ -1,0 +1,57 @@
+"""Round-trip tests: cli/*.py -> cabs/*.yml -> regenerated cli/*.py.
+
+These tests are how this project guarantees that the source under cli/ and the
+generated cab YAMLs under cabs/ stay in agreement. They run hip-cargo's
+generate-cabs then generate-function, and assert the regenerated source is
+byte-identical to the original (both are ruff-formatted with the same config).
+
+Add a new test case here for every command you add under src/<PACKAGE_NAME>/cli/.
+"""
+
+import tempfile
+from pathlib import Path
+
+from hip_cargo.core.generate_cabs import generate_cabs
+from hip_cargo.core.generate_function import generate_function
+
+
+def _assert_roundtrip(command_name: str) -> None:
+    """Round-trip cli/<command>.py through a cab and back; assert byte-identical."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        cab_dir = tmpdir / "cabs"
+        cab_dir.mkdir()
+
+        cli_module = Path(f"src/<PACKAGE_NAME>/cli/{command_name}.py")
+        assert cli_module.exists(), f"Missing CLI module: {cli_module}"
+
+        generate_cabs([cli_module], output_dir=cab_dir)
+
+        cab_file = cab_dir / f"{command_name}.yml"
+        assert cab_file.exists(), f"generate-cabs did not produce {cab_file}"
+
+        generated_file = tmpdir / f"{command_name}_roundtrip.py"
+        generate_function(
+            cab_file,
+            output_file=generated_file,
+            config_file=Path("pyproject.toml"),
+        )
+
+        assert generated_file.exists(), "generate-function did not produce output"
+        generated_code = generated_file.read_text()
+        compile(generated_code, str(generated_file), "exec")
+
+        original_lines = cli_module.read_text().splitlines()
+        generated_lines = generated_code.splitlines()
+
+        assert len(original_lines) == len(generated_lines), (
+            f"Line count mismatch for {command_name}: "
+            f"original has {len(original_lines)} lines, generated has {len(generated_lines)} lines"
+        )
+        for i, (orig, gen) in enumerate(zip(original_lines, generated_lines), 1):
+            assert orig == gen, f"Line {i} differs in {command_name}:\n  Original:  {orig}\n  Generated: {gen}"
+
+
+def test_roundtrip_onboard() -> None:
+    """The onboard command must round-trip cleanly through a cab."""
+    _assert_roundtrip("onboard")

--- a/src/hip_cargo/templates/workflows/update-cabs.yml
+++ b/src/hip_cargo/templates/workflows/update-cabs.yml
@@ -59,7 +59,7 @@ jobs:
           "
 
       - name: Regenerate cab definitions with latest tag
-        run: uv run <CLI_COMMAND> generate-cabs --module 'src/<PACKAGE_NAME>/cli/*.py' --output-dir src/<PACKAGE_NAME>/cabs
+        run: uv run hip-cargo generate-cabs --module 'src/<PACKAGE_NAME>/cli/*.py' --output-dir src/<PACKAGE_NAME>/cabs
 
       - name: Check for changes
         id: check_changes

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,6 +29,7 @@ def test_init_produces_clean_project():
             "pyproject.toml",
             "tbump.toml",
             "Dockerfile",
+            "CLAUDE.md",
             ".gitignore",
             ".pre-commit-config.yaml",
             "LICENSE",
@@ -47,6 +48,7 @@ def test_init_produces_clean_project():
             f"src/{pkg}/cabs/__init__.py",
             "tests/__init__.py",
             "tests/test_install.py",
+            "tests/test_roundtrip.py",
         ]
         for filepath in expected_files:
             assert (project_dir / filepath).exists(), f"Missing scaffold file: {filepath}"


### PR DESCRIPTION
Expand templates to give agents more context of the expected project structure after a fresh init. Fix a couple of misplaced <CLI_COMMAND> entries